### PR TITLE
über-pedantic ~ deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Details can be found on the emacs-mac-port [README][emacs-mac-port-server].
 1. If you have an existing Emacs configuration, back it up:
 
    ```sh
-   cd ~
+   cd
    mv .emacs.d .emacs.bak
    ```
 


### PR DESCRIPTION
This is by no means a necessary change. But the POSIX default destination of cd is in fact ~. 
